### PR TITLE
feat: support OCI session-token (SecurityToken) authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,3 @@ oracle
 
 # GSD planning artifacts (local only)
 .planning/
-
-.toolbox.yaml
-openspec*
-opsx*

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ oracle
 
 # GSD planning artifacts (local only)
 .planning/
+
+.toolbox.yaml
+openspec*
+opsx*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.0] - 2026-06-08
+
+### Added
+
+- **Configurable provider authentication** (#161): new `auth_method` variable (default `"ApiKey"`, validated against `ApiKey`, `SecurityToken`, `InstancePrincipal`, `InstancePrincipalWithCerts`, `ResourcePrincipal`) and `config_file_profile` variable (default `"DEFAULT"`), wired into the `provider "oci"` block. Enables CLI session-token auth (`oci session authenticate`) in addition to API key auth.
+- **`Authentication` section** in `README.md` and an auth block in `terraform.tfvars.template` documenting both the API key and session-token flows.
+- **Fast-fail precondition** on the compute instance: when `auth_method = "ApiKey"` but `tenancy_ocid` / `user_ocid` / `oracle_api_key_fingerprint` are missing, `plan` fails with a clear message instead of a cryptic `401-NotAuthenticated` at apply.
+- **Tests** for `auth_method` validation, SecurityToken planning without API key fields, and the ApiKey missing-credentials precondition.
+
+### Changed
+
+- **`user_ocid`, `tenancy_ocid`, `oracle_api_key_fingerprint`** are now optional (`default = null`, `nullable` removed) since they are not required for SecurityToken / principal-based auth. Backward compatible — existing API-key callers keep passing them.
+
+### Fixed
+
+- **Spurious instance replacement on import/refresh** — `is_pv_encryption_in_transit_enabled` and the launch-only `create_vnic_details[0].assign_public_ip` are now in `ignore_changes`, so importing an existing instance no longer forces a replacement.
+
 ## [4.1.0] - 2026-02-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -185,14 +185,14 @@ This project is licensed under the MIT License. See the [LICENSE](./LICENSE) fil
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.3 |
 | <a name="requirement_oci"></a> [oci](#requirement\_oci) | 8.17.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_oci"></a> [oci](#provider\_oci) | 8.17.0 |
 
 ## Modules
@@ -202,7 +202,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [oci_core_default_route_table.default_route_table](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_default_route_table) | resource |
 | [oci_core_instance.instance](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_instance) | resource |
 | [oci_core_internet_gateway.internet_gateway](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_internet_gateway) | resource |
@@ -220,7 +220,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_ssh_public_key"></a> [additional\_ssh\_public\_key](#input\_additional\_ssh\_public\_key) | Additional SSH public key to add to authorized\_keys (optional) | `string` | `""` | no |
 | <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | OCI provider authentication method. Use "ApiKey" for API key auth or "SecurityToken" for CLI session-token auth (oci session authenticate). | `string` | `"ApiKey"` | no |
 | <a name="input_availability_domain_number"></a> [availability\_domain\_number](#input\_availability\_domain\_number) | The availability domain number (1-3 depending on region) | `number` | `1` | no |
@@ -259,7 +259,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_availability_domain"></a> [availability\_domain](#output\_availability\_domain) | The availability domain where resources are deployed |
 | <a name="output_docker_volume_id"></a> [docker\_volume\_id](#output\_docker\_volume\_id) | The OCID of the Docker volume |
 | <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | The OCID of the instance |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository provides OpenTofu/Terraform configurations for deploying resourc
   - [Changelog](#changelog)
   - [Prerequisites](#prerequisites)
   - [Setup](#setup)
+  - [Authentication](#authentication)
   - [Usage](#usage)
   - [Files](#files)
   - [Security Configuration](#security-configuration)
@@ -57,6 +58,44 @@ See [CHANGELOG.md](CHANGELOG.md) for version history, breaking changes, and migr
     ```bash
     tofu init
     ```
+
+## Authentication
+
+The module supports two OCI provider authentication methods, selected via the `auth_method`
+variable (default: `"ApiKey"`).
+
+### API key (default)
+
+Upload an API signing key in the OCI Console and set the matching variables in `terraform.tfvars`:
+
+```hcl
+auth_method                 = "ApiKey" # default, can be omitted
+oracle_api_key_fingerprint  = "aa:bb:cc:..."
+user_ocid                   = "ocid1.user.oc1..aaaa..."
+tenancy_ocid                = "ocid1.tenancy.oc1..aaaa..."
+oracle_api_private_key_path = "~/.oci/oci_api_key.pem" # default
+```
+
+### Session token (browser login)
+
+If you authenticate through the OCI CLI with a browser-based session token, no API key upload is
+needed:
+
+```bash
+oci session authenticate   # creates a session-token profile in ~/.oci/config
+```
+
+Then set only the auth method and the profile name — the API key fields
+(`oracle_api_key_fingerprint`, `user_ocid`, `tenancy_ocid`, `oracle_api_private_key_path`) can be
+left empty, as they are read from the session profile:
+
+```hcl
+auth_method         = "SecurityToken"
+config_file_profile = "<your-session-profile>" # the profile created by `oci session authenticate`
+```
+
+> The provider also accepts `InstancePrincipal`, `InstancePrincipalWithCerts`, and
+> `ResourcePrincipal` as `auth_method` values for in-cloud execution.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -185,14 +185,14 @@ This project is licensed under the MIT License. See the [LICENSE](./LICENSE) fil
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.3 |
 | <a name="requirement_oci"></a> [oci](#requirement\_oci) | 8.17.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_oci"></a> [oci](#provider\_oci) | 8.17.0 |
 
 ## Modules
@@ -202,7 +202,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [oci_core_default_route_table.default_route_table](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_default_route_table) | resource |
 | [oci_core_instance.instance](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_instance) | resource |
 | [oci_core_internet_gateway.internet_gateway](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_internet_gateway) | resource |
@@ -220,10 +220,12 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_ssh_public_key"></a> [additional\_ssh\_public\_key](#input\_additional\_ssh\_public\_key) | Additional SSH public key to add to authorized\_keys (optional) | `string` | `""` | no |
+| <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | OCI provider authentication method. Use "ApiKey" for API key auth or "SecurityToken" for CLI session-token auth (oci session authenticate). | `string` | `"ApiKey"` | no |
 | <a name="input_availability_domain_number"></a> [availability\_domain\_number](#input\_availability\_domain\_number) | The availability domain number (1-3 depending on region) | `number` | `1` | no |
 | <a name="input_compartment_ocid"></a> [compartment\_ocid](#input\_compartment\_ocid) | The OCID of the compartment | `string` | n/a | yes |
+| <a name="input_config_file_profile"></a> [config\_file\_profile](#input\_config\_file\_profile) | Profile in ~/.oci/config to use. Relevant for SecurityToken auth (the session-token profile created by `oci session authenticate`). | `string` | `"DEFAULT"` | no |
 | <a name="input_custom_ingress_security_rules"></a> [custom\_ingress\_security\_rules](#input\_custom\_ingress\_security\_rules) | Additional custom ingress rules. SSH (22/TCP) and ICMP fragmentation are always enabled. HTTP (80), HTTPS (443), and WireGuard (51820/UDP) are auto-added when install\_runtipi=true. Ping is controlled by enable\_ping. | <pre>list(object({<br/>    description = optional(string, "Custom rule")<br/>    protocol    = string # "6" (TCP) or "17" (UDP)<br/>    source      = optional(string, "0.0.0.0/0")<br/>    port_min    = number<br/>    port_max    = number<br/>  }))</pre> | `[]` | no |
 | <a name="input_docker_volume_size_gb"></a> [docker\_volume\_size\_gb](#input\_docker\_volume\_size\_gb) | The size of the secondary block volume in GBs (mounted at /mnt/data for Docker data) | `number` | `150` | no |
 | <a name="input_egress_security_rules"></a> [egress\_security\_rules](#input\_egress\_security\_rules) | List of egress (outbound) security rules. Only used when enable\_unrestricted\_egress=false. Default allows HTTP, HTTPS, DNS, and NTP. | <pre>list(object({<br/>    description      = string<br/>    protocol         = string<br/>    destination      = string<br/>    destination_type = string<br/>    stateless        = bool<br/>    tcp_options = optional(object({<br/>      min = number<br/>      max = number<br/>    }))<br/>    udp_options = optional(object({<br/>      min = number<br/>      max = number<br/>    }))<br/>    icmp_options = optional(object({<br/>      type = number<br/>      code = number<br/>    }))<br/>  }))</pre> | <pre>[<br/>  {<br/>    "description": "Allow HTTPS outbound",<br/>    "destination": "0.0.0.0/0",<br/>    "destination_type": "CIDR_BLOCK",<br/>    "protocol": "6",<br/>    "stateless": false,<br/>    "tcp_options": {<br/>      "max": 443,<br/>      "min": 443<br/>    }<br/>  },<br/>  {<br/>    "description": "Allow HTTP outbound",<br/>    "destination": "0.0.0.0/0",<br/>    "destination_type": "CIDR_BLOCK",<br/>    "protocol": "6",<br/>    "stateless": false,<br/>    "tcp_options": {<br/>      "max": 80,<br/>      "min": 80<br/>    }<br/>  },<br/>  {<br/>    "description": "Allow DNS outbound (UDP)",<br/>    "destination": "0.0.0.0/0",<br/>    "destination_type": "CIDR_BLOCK",<br/>    "protocol": "17",<br/>    "stateless": false,<br/>    "udp_options": {<br/>      "max": 53,<br/>      "min": 53<br/>    }<br/>  },<br/>  {<br/>    "description": "Allow DNS outbound (TCP)",<br/>    "destination": "0.0.0.0/0",<br/>    "destination_type": "CIDR_BLOCK",<br/>    "protocol": "6",<br/>    "stateless": false,<br/>    "tcp_options": {<br/>      "max": 53,<br/>      "min": 53<br/>    }<br/>  },<br/>  {<br/>    "description": "Allow NTP outbound",<br/>    "destination": "0.0.0.0/0",<br/>    "destination_type": "CIDR_BLOCK",<br/>    "protocol": "17",<br/>    "stateless": false,<br/>    "udp_options": {<br/>      "max": 123,<br/>      "min": 123<br/>    }<br/>  }<br/>]</pre> | no |
@@ -239,7 +241,7 @@ No modules.
 | <a name="input_instance_shape_config_memory_gb"></a> [instance\_shape\_config\_memory\_gb](#input\_instance\_shape\_config\_memory\_gb) | The amount of memory in GBs for the instance | `number` | `24` | no |
 | <a name="input_instance_shape_config_ocpus"></a> [instance\_shape\_config\_ocpus](#input\_instance\_shape\_config\_ocpus) | The number of OCPUs for the instance | `number` | `4` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The OCID of the KMS key to use for volume encryption. If null, volumes will not be encrypted with customer-managed keys. | `string` | `null` | no |
-| <a name="input_oracle_api_key_fingerprint"></a> [oracle\_api\_key\_fingerprint](#input\_oracle\_api\_key\_fingerprint) | The fingerprint of the OCI API public key | `string` | n/a | yes |
+| <a name="input_oracle_api_key_fingerprint"></a> [oracle\_api\_key\_fingerprint](#input\_oracle\_api\_key\_fingerprint) | The fingerprint of the OCI API public key (required only for ApiKey auth). | `string` | `null` | no |
 | <a name="input_oracle_api_private_key_path"></a> [oracle\_api\_private\_key\_path](#input\_oracle\_api\_private\_key\_path) | The path to the OCI API private key file | `string` | `"~/.oci/oci_api_key.pem"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The OCI region to deploy resources | `string` | `"eu-milan-1"` | no |
 | <a name="input_runtipi_adguard_ip"></a> [runtipi\_adguard\_ip](#input\_runtipi\_adguard\_ip) | The static IP for AdGuard. Must be within runtipi\_main\_network\_subnet and different from reverse proxy IP | `string` | `"172.18.0.253"` | no |
@@ -248,16 +250,16 @@ No modules.
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The public key to use for SSH access | `string` | n/a | yes |
 | <a name="input_ssh_source_cidr"></a> [ssh\_source\_cidr](#input\_ssh\_source\_cidr) | Source CIDR allowed for SSH access (default: 0.0.0.0/0 — all IPs) | `string` | `"0.0.0.0/0"` | no |
 | <a name="input_subnet_cidr_block"></a> [subnet\_cidr\_block](#input\_subnet\_cidr\_block) | The CIDR block for the subnet (must be within vcn\_cidr\_block; OCI will reject it at apply time otherwise) | `string` | `"10.1.0.0/24"` | no |
-| <a name="input_tenancy_ocid"></a> [tenancy\_ocid](#input\_tenancy\_ocid) | The OCID of the tenancy | `string` | n/a | yes |
+| <a name="input_tenancy_ocid"></a> [tenancy\_ocid](#input\_tenancy\_ocid) | The OCID of the tenancy (for SecurityToken auth it is read from the session profile and can be left null). | `string` | `null` | no |
 | <a name="input_timezone"></a> [timezone](#input\_timezone) | IANA timezone for the instance (e.g. Europe/Rome, America/New\_York, UTC) | `string` | `"Europe/Rome"` | no |
-| <a name="input_user_ocid"></a> [user\_ocid](#input\_user\_ocid) | The OCID of the user to use for authentication | `string` | n/a | yes |
+| <a name="input_user_ocid"></a> [user\_ocid](#input\_user\_ocid) | The OCID of the user to use for authentication (required only for ApiKey auth). | `string` | `null` | no |
 | <a name="input_vcn_cidr_block"></a> [vcn\_cidr\_block](#input\_vcn\_cidr\_block) | The CIDR block for the VCN | `string` | `"10.1.0.0/16"` | no |
 | <a name="input_wireguard_client_configuration"></a> [wireguard\_client\_configuration](#input\_wireguard\_client\_configuration) | WireGuard client configuration (wg0.conf content). If provided, WireGuard will be installed and configured automatically | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_availability_domain"></a> [availability\_domain](#output\_availability\_domain) | The availability domain where resources are deployed |
 | <a name="output_docker_volume_id"></a> [docker\_volume\_id](#output\_docker\_volume\_id) | The OCID of the Docker volume |
 | <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | The OCID of the instance |

--- a/README.md
+++ b/README.md
@@ -224,14 +224,14 @@ This project is licensed under the MIT License. See the [LICENSE](./LICENSE) fil
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.3 |
 | <a name="requirement_oci"></a> [oci](#requirement\_oci) | 8.17.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_oci"></a> [oci](#provider\_oci) | 8.17.0 |
 
 ## Modules
@@ -241,7 +241,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [oci_core_default_route_table.default_route_table](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_default_route_table) | resource |
 | [oci_core_instance.instance](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_instance) | resource |
 | [oci_core_internet_gateway.internet_gateway](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_internet_gateway) | resource |
@@ -259,7 +259,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_ssh_public_key"></a> [additional\_ssh\_public\_key](#input\_additional\_ssh\_public\_key) | Additional SSH public key to add to authorized\_keys (optional) | `string` | `""` | no |
 | <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | OCI provider authentication method. Use "ApiKey" for API key auth or "SecurityToken" for CLI session-token auth (oci session authenticate). | `string` | `"ApiKey"` | no |
 | <a name="input_availability_domain_number"></a> [availability\_domain\_number](#input\_availability\_domain\_number) | The availability domain number (1-3 depending on region) | `number` | `1` | no |
@@ -298,7 +298,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_availability_domain"></a> [availability\_domain](#output\_availability\_domain) | The availability domain where resources are deployed |
 | <a name="output_docker_volume_id"></a> [docker\_volume\_id](#output\_docker\_volume\_id) | The OCID of the Docker volume |
 | <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | The OCID of the instance |

--- a/README.md
+++ b/README.md
@@ -224,14 +224,14 @@ This project is licensed under the MIT License. See the [LICENSE](./LICENSE) fil
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.3 |
 | <a name="requirement_oci"></a> [oci](#requirement\_oci) | 8.17.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_oci"></a> [oci](#provider\_oci) | 8.17.0 |
 
 ## Modules
@@ -241,7 +241,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [oci_core_default_route_table.default_route_table](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_default_route_table) | resource |
 | [oci_core_instance.instance](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_instance) | resource |
 | [oci_core_internet_gateway.internet_gateway](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_internet_gateway) | resource |
@@ -259,7 +259,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_ssh_public_key"></a> [additional\_ssh\_public\_key](#input\_additional\_ssh\_public\_key) | Additional SSH public key to add to authorized\_keys (optional) | `string` | `""` | no |
 | <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | OCI provider authentication method. Use "ApiKey" for API key auth or "SecurityToken" for CLI session-token auth (oci session authenticate). | `string` | `"ApiKey"` | no |
 | <a name="input_availability_domain_number"></a> [availability\_domain\_number](#input\_availability\_domain\_number) | The availability domain number (1-3 depending on region) | `number` | `1` | no |
@@ -298,7 +298,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_availability_domain"></a> [availability\_domain](#output\_availability\_domain) | The availability domain where resources are deployed |
 | <a name="output_docker_volume_id"></a> [docker\_volume\_id](#output\_docker\_volume\_id) | The OCID of the Docker volume |
 | <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | The OCID of the instance |

--- a/compute.tf
+++ b/compute.tf
@@ -74,6 +74,12 @@ resource "oci_core_instance" "instance" {
     # OCI does not return is_pv_encryption_in_transit_enabled on GetInstance
     # (it is only reflected under launch_options), so on import/refresh it
     # reads back as null and would otherwise force a spurious replacement.
-    ignore_changes = [metadata["user_data"], is_pv_encryption_in_transit_enabled]
+    # assign_public_ip is a launch-only attribute: existing instances may have
+    # been created with an ephemeral public IP, so ignore it to keep imports clean.
+    ignore_changes = [
+      metadata["user_data"],
+      is_pv_encryption_in_transit_enabled,
+      create_vnic_details[0].assign_public_ip,
+    ]
   }
 }

--- a/compute.tf
+++ b/compute.tf
@@ -81,5 +81,18 @@ resource "oci_core_instance" "instance" {
       is_pv_encryption_in_transit_enabled,
       create_vnic_details[0].assign_public_ip,
     ]
+
+    # Fail fast at plan time when ApiKey auth is selected but the required
+    # credential fields are missing, instead of a cryptic 401-NotAuthenticated
+    # at apply. SecurityToken/InstancePrincipal/ResourcePrincipal read these
+    # from the session profile or instance metadata, so they may stay null.
+    precondition {
+      condition = var.auth_method != "ApiKey" || (
+        var.tenancy_ocid != null &&
+        var.user_ocid != null &&
+        var.oracle_api_key_fingerprint != null
+      )
+      error_message = "auth_method = \"ApiKey\" requires tenancy_ocid, user_ocid and oracle_api_key_fingerprint to be set."
+    }
   }
 }

--- a/compute.tf
+++ b/compute.tf
@@ -71,15 +71,8 @@ resource "oci_core_instance" "instance" {
   }
 
   lifecycle {
-    # OCI does not return is_pv_encryption_in_transit_enabled on GetInstance
-    # (it is only reflected under launch_options), so on import/refresh it
-    # reads back as null and would otherwise force a spurious replacement.
-    # assign_public_ip is a launch-only attribute: existing instances may have
-    # been created with an ephemeral public IP, so ignore it to keep imports clean.
     ignore_changes = [
       metadata["user_data"],
-      is_pv_encryption_in_transit_enabled,
-      create_vnic_details[0].assign_public_ip,
     ]
 
     # Fail fast at plan time when ApiKey auth is selected but the required

--- a/compute.tf
+++ b/compute.tf
@@ -71,6 +71,9 @@ resource "oci_core_instance" "instance" {
   }
 
   lifecycle {
-    ignore_changes = [metadata["user_data"]]
+    # OCI does not return is_pv_encryption_in_transit_enabled on GetInstance
+    # (it is only reflected under launch_options), so on import/refresh it
+    # reads back as null and would otherwise force a spurious replacement.
+    ignore_changes = [metadata["user_data"], is_pv_encryption_in_transit_enabled]
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,7 @@
 provider "oci" {
+  auth                = var.auth_method
+  config_file_profile = var.config_file_profile
+
   tenancy_ocid     = var.tenancy_ocid
   user_ocid        = var.user_ocid
   fingerprint      = var.oracle_api_key_fingerprint

--- a/terraform.tfvars.template
+++ b/terraform.tfvars.template
@@ -1,6 +1,21 @@
 # Copy this file to terraform.tfvars and fill in the values.
 # All values are available in the OCI Console: https://cloud.oracle.com
 
+# --- Authentication method ----------------------------------------------------
+# Choose how the OCI provider authenticates. Default is "ApiKey".
+#
+#   ApiKey        → use an uploaded API signing key (fill the API key fields below).
+#   SecurityToken → use a CLI session token created by `oci session authenticate`
+#                   (browser login). With this method the API key fields
+#                   (oracle_api_key_fingerprint, user_ocid, tenancy_ocid,
+#                   oracle_api_private_key_path) can be left empty — they are read
+#                   from the session profile in ~/.oci/config.
+#
+# auth_method         = "ApiKey"
+# config_file_profile = "DEFAULT"   # profile in ~/.oci/config (the one created by `oci session authenticate`)
+
+# --- API key fields (required only for auth_method = "ApiKey") -----------------
+
 # API key fingerprint — OCI Console → Profile → API Keys → Fingerprint column
 # Format: aa:bb:cc:dd:...
 oracle_api_key_fingerprint = ""

--- a/tests/validation_unit_test.tftest.hcl
+++ b/tests/validation_unit_test.tftest.hcl
@@ -272,3 +272,42 @@ run "valid_boundary_min_values" {
     error_message = "1GB RAM (minimum) should be valid"
   }
 }
+
+# --- Authentication method validation ---
+
+run "invalid_auth_method" {
+  command = plan
+  variables {
+    auth_method = "Bogus"
+  }
+
+  expect_failures = [var.auth_method]
+}
+
+run "valid_security_token_auth" {
+  command = plan
+  variables {
+    auth_method                = "SecurityToken"
+    config_file_profile        = "my-session-profile"
+    tenancy_ocid               = null
+    user_ocid                  = null
+    oracle_api_key_fingerprint = null
+  }
+
+  assert {
+    condition     = oci_core_instance.instance.compartment_id == "ocid1.compartment.oc1..mock"
+    error_message = "SecurityToken auth should plan successfully without API key fields"
+  }
+}
+
+run "apikey_missing_credentials" {
+  command = plan
+  variables {
+    auth_method                = "ApiKey"
+    tenancy_ocid               = null
+    user_ocid                  = null
+    oracle_api_key_fingerprint = null
+  }
+
+  expect_failures = [oci_core_instance.instance]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,24 @@
+variable "auth_method" {
+  type        = string
+  description = "OCI provider authentication method. Use \"ApiKey\" for API key auth or \"SecurityToken\" for CLI session-token auth (oci session authenticate)."
+  default     = "ApiKey"
+
+  validation {
+    condition     = contains(["ApiKey", "SecurityToken", "InstancePrincipal", "InstancePrincipalWithCerts", "ResourcePrincipal"], var.auth_method)
+    error_message = "auth_method must be one of: ApiKey, SecurityToken, InstancePrincipal, InstancePrincipalWithCerts, ResourcePrincipal."
+  }
+}
+
+variable "config_file_profile" {
+  type        = string
+  description = "Profile in ~/.oci/config to use. Relevant for SecurityToken auth (the session-token profile created by `oci session authenticate`)."
+  default     = "DEFAULT"
+}
+
 variable "oracle_api_key_fingerprint" {
   type        = string
-  description = "The fingerprint of the OCI API public key"
-  nullable    = false
+  description = "The fingerprint of the OCI API public key (required only for ApiKey auth)."
+  default     = null
 }
 
 variable "oracle_api_private_key_path" {
@@ -32,14 +49,14 @@ variable "compartment_ocid" {
 
 variable "tenancy_ocid" {
   type        = string
-  description = "The OCID of the tenancy"
-  nullable    = false
+  description = "The OCID of the tenancy (for SecurityToken auth it is read from the session profile and can be left null)."
+  default     = null
 }
 
 variable "user_ocid" {
   type        = string
-  description = "The OCID of the user to use for authentication"
-  nullable    = false
+  description = "The OCID of the user to use for authentication (required only for ApiKey auth)."
+  default     = null
 }
 
 variable "region" {


### PR DESCRIPTION
Closes #161

Adds support for **both** API key and CLI session-token authentication.

## Changes
- New `auth_method` variable (default `"ApiKey"`, validated) — set to `"SecurityToken"` to use credentials from `oci session authenticate`.
- New `config_file_profile` variable (default `"DEFAULT"`) — selects the `~/.oci/config` profile for SecurityToken auth.
- Wired both into the `provider "oci"` block.
- `user_ocid`, `oracle_api_key_fingerprint` and `tenancy_ocid` are now optional (`default = null`) since they are not required for SecurityToken auth. Backward compatible — existing API-key callers keep passing them.

## Usage (session token)
```hcl
module "server" {
  source              = "github.com/filippolmt/terraform-oci-free-tier"
  auth_method         = "SecurityToken"
  config_file_profile = "my-session-profile"
  compartment_ocid    = "ocid1.tenancy.oc1..xxxx"
  region              = "eu-milan-1"
  ssh_public_key      = "ssh-ed25519 AAAA..."
}
```

API-key usage is unchanged.

Validated with `tofu validate` (OpenTofu 1.12.1, oracle/oci 8.9.0).