### PR TITLE
fix(startup): open host firewall to match OCI security list

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,14 +224,14 @@ This project is licensed under the MIT License. See the [LICENSE](./LICENSE) fil
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.3 |
 | <a name="requirement_oci"></a> [oci](#requirement\_oci) | 8.17.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_oci"></a> [oci](#provider\_oci) | 8.17.0 |
 
 ## Modules
@@ -241,7 +241,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [oci_core_default_route_table.default_route_table](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_default_route_table) | resource |
 | [oci_core_instance.instance](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_instance) | resource |
 | [oci_core_internet_gateway.internet_gateway](https://registry.terraform.io/providers/oracle/oci/8.17.0/docs/resources/core_internet_gateway) | resource |
@@ -259,7 +259,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_ssh_public_key"></a> [additional\_ssh\_public\_key](#input\_additional\_ssh\_public\_key) | Additional SSH public key to add to authorized\_keys (optional) | `string` | `""` | no |
 | <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | OCI provider authentication method. Use "ApiKey" for API key auth or "SecurityToken" for CLI session-token auth (oci session authenticate). | `string` | `"ApiKey"` | no |
 | <a name="input_availability_domain_number"></a> [availability\_domain\_number](#input\_availability\_domain\_number) | The availability domain number (1-3 depending on region) | `number` | `1` | no |
@@ -298,7 +298,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_availability_domain"></a> [availability\_domain](#output\_availability\_domain) | The availability domain where resources are deployed |
 | <a name="output_docker_volume_id"></a> [docker\_volume\_id](#output\_docker\_volume\_id) | The OCID of the Docker volume |
 | <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | The OCID of the instance |

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -351,8 +351,13 @@ fi
 # nothing unexpected keeps listening on 0.0.0.0 once the host filter is relaxed.
 # Non-fatal when a unit is not installed.
 log "Disabling unused locally-listening services (cups, cups-browsed, rpcbind)"
-systemctl disable --now cups cups-browsed rpcbind 2>/dev/null ||
-  log "One or more of cups/cups-browsed/rpcbind not installed, skipping"
+for svc in cups cups-browsed rpcbind; do
+  if systemctl disable --now "$svc" 2>/dev/null; then
+    log "Disabled $svc"
+  else
+    log "$svc not present or already disabled, skipping"
+  fi
+done
 
 # Install Runtipi
 if [ "${INSTALL_RUNTIPI}" = "true" ]; then

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -314,6 +314,46 @@ EOF
   log "Docker configured to wait for $MNT_DIR mount on boot"
 fi
 
+# Reconcile the host packet filter with the OCI security list.
+# The Oracle Ubuntu image ships an INPUT chain ending in a catch-all REJECT,
+# so only SSH is reachable and ports opened in network.tf are dropped at the
+# host. The OCI security list is the single source of truth for inbound
+# reachability, so remove only that catch-all REJECT (IPv4 + IPv6), leaving
+# RELATED,ESTABLISHED, lo, icmp, and SSH rules intact. Guarded/non-fatal.
+log "Reconciling host packet filter with OCI security list"
+if iptables -C INPUT -j REJECT --reject-with icmp-host-prohibited 2>/dev/null; then
+  iptables -D INPUT -j REJECT --reject-with icmp-host-prohibited
+  log "Removed IPv4 catch-all REJECT rule from INPUT chain"
+else
+  log "IPv4 catch-all REJECT rule not present, nothing to remove"
+fi
+
+if ip6tables -C INPUT -j REJECT --reject-with icmp6-adm-prohibited 2>/dev/null; then
+  ip6tables -D INPUT -j REJECT --reject-with icmp6-adm-prohibited
+  log "Removed IPv6 catch-all REJECT rule from INPUT chain"
+else
+  log "IPv6 catch-all REJECT rule not present, nothing to remove"
+fi
+
+# Persist the ruleset so it survives reboot (iptables-persistent ships on the
+# Oracle image). Guard against a future base image lacking the tool.
+if command -v netfilter-persistent >/dev/null 2>&1; then
+  if netfilter-persistent save; then
+    log "Persisted netfilter ruleset"
+  else
+    log_error "netfilter-persistent save failed; firewall change may not persist across reboot"
+  fi
+else
+  log_error "netfilter-persistent not found; firewall change will not persist across reboot"
+fi
+
+# Disable network-exposed services with no role on a headless cloud server so
+# nothing unexpected keeps listening on 0.0.0.0 once the host filter is relaxed.
+# Non-fatal when a unit is not installed.
+log "Disabling unused locally-listening services (cups, cups-browsed, rpcbind)"
+systemctl disable --now cups cups-browsed rpcbind 2>/dev/null ||
+  log "One or more of cups/cups-browsed/rpcbind not installed, skipping"
+
 # Install Runtipi
 if [ "${INSTALL_RUNTIPI}" = "true" ]; then
   log "Install Runtipi"


### PR DESCRIPTION
## Why

The Oracle Ubuntu cloud image ships a restrictive netfilter `INPUT` chain ending in a catch-all `REJECT`, so only SSH (22) is reachable. Ports the module opens in the OCI security list (`network.tf`) — 80/443/51820 for RunTipi, ICMP, and any `custom_ingress_security_rules` — were dropped at the host, so any advertised service was silently unreachable (issue #164.1).

## What changed

- **`scripts/startup.sh` (Phase B) only.** No Terraform changes.
- Idempotently remove **only** Oracle's catch-all `REJECT` rule for both IPv4 (`icmp-host-prohibited`) and IPv6 (`icmp6-adm-prohibited`), guarded/non-fatal when absent. `RELATED,ESTABLISHED`, `lo`, `icmp`, and SSH rules stay intact.
- Persist via `netfilter-persistent save` (guarded if the tool is missing) so the change survives reboot.
- Disable `cups`/`cups-browsed`/`rpcbind` (non-fatal if absent) so nothing unexpected keeps listening on `0.0.0.0` once the host filter is relaxed — folds in #165.1.

## Security model

Shifts from two overlapping firewalls (OCI security list + host netfilter) to a **single source of truth**: the OCI security list (validated in `variables.tf`). Acceptable for a single free-tier instance with no east-west traffic; defense-in-depth against unexpected listeners is preserved by disabling cups/rpcbind.

After this change: opening a port in `custom_ingress_security_rules` + `tofu apply` makes it actually reachable — no host-side action needed.

## Verification

- `make shellcheck` ✓
- `make tofu-test` ✓ (no Terraform changes)
- Live Oracle VM audit confirmed: `iptables`/`ip6tables`/`netfilter-persistent`/`systemctl`/`ss` all present; IPv4 INPUT has the catch-all `REJECT` (target), IPv6 has none (guard exercised); `rpcbind`:111 and `cupsd`:631 listening on `0.0.0.0`.
- Manual on a freshly provisioned instance (post-merge): `sudo iptables -S INPUT` shows no catch-all `REJECT`; opened-port service reachable; `ss -tlnp` shows no cups/rpcbind; rules persist after reboot.

## Migration note

Applies on **next provisioning** (completion marker `/var/log/.setup_script_completed` prevents re-run on existing hosts). To apply on an already-running host:

\`\`\`bash
sudo iptables -D INPUT -j REJECT --reject-with icmp-host-prohibited
sudo netfilter-persistent save
sudo systemctl disable --now cups cups-browsed rpcbind
\`\`\`

Closes #164
Refs #165 (folds in #165.1)